### PR TITLE
[Fix #9] Ensure Services can be uninstalled

### DIFF
--- a/services-installer.sh
+++ b/services-installer.sh
@@ -98,7 +98,6 @@ chattr -i /mnt/secure/etc
 chattr -i /mnt/secure/init.d/*
 rm -rf /mnt/secure/init.d #old location
 rm -f /mnt/secure/rcS #old location
-rm -f /mnt/secure/.pkgver
 rm -rf /mnt/secure/etc /mnt/secure/bin /mnt/secure/lib
 
 echo "Extracting"


### PR DESCRIPTION
The services install script was removing the `.pkgver` file after it has been created, therefore preventing the uninstall to work.
With this fix I was able to uninstall Services.

For already installed services, upload the new script, and launch it twice (one to overwrite the install and one to uninstall)